### PR TITLE
Simplify 13. Roman to Integer

### DIFF
--- a/JS/13. Roman to Integer.js
+++ b/JS/13. Roman to Integer.js
@@ -3,69 +3,21 @@
  * @param {string} s
  * @return {number}
  */
-//  Roman numerals are represented by seven different symbols: I, V, X, L, C, D and M.
-
-//  Symbol       Value
-//  I             1
-//  V             5
-//  X             10
-//  L             50
-//  C             100
-//  D             500
-//  M             1000
-//  For example, 2 is written as II in Roman numeral, just two ones added together. 12 is written as XII, which is simply X + II. The number 27 is written as XXVII, which is XX + V + II.
-
-//  Roman numerals are usually written largest to smallest from left to right. However, the numeral for four is not IIII. Instead, the number four is written as IV. Because the one is before the five we subtract it making four. The same principle applies to the number nine, which is written as IX. There are six instances where subtraction is used:
-
-//  I can be placed before V (5) and X (10) to make 4 and 9.
-//  X can be placed before L (50) and C (100) to make 40 and 90.
-//  C can be placed before D (500) and M (1000) to make 400 and 900.
-//  Given a roman numeral, convert it to an integer.
-
-//  Example 1:
-
-//  Input: s = "III"
-//  Output: 3
-//  Explanation: III = 3.
-//  Example 2:
-
-//  Input: s = "LVIII"
-//  Output: 58
-//  Explanation: L = 50, V= 5, III = 3.
-//  Example 3:
-
-//  Input: s = "MCMXCIV"
-//  Output: 1994
-//  Explanation: M = 1000, CM = 900, XC = 90 and IV = 4.
-
-var romanToInt = function (s) {
-  let roman = {
-    I: 1,
-    V: 5,
-    X: 10,
-    L: 50,
-    C: 100,
-    D: 500,
-    M: 1000,
-  };
-  let sum = 0;
-
-  // From beginning to end ...
-  for (let i = 0; i < s.length; i++) {
-    const key = s[i];
-    const romanVariant = roman[key];
-
-    const nextKey = s[i + 1];
-    const nextRomanVariant = roman[nextKey];
-
-    const isInBounds = i + 1 < s.length;
-
-    if (isInBounds && romanVariant < nextRomanVariant) {
-      sum -= romanVariant;
-    } else {
-      sum += romanVariant;
-    }
-  }
-
-  return sum;
-};
+function romanToInt(s) {
+    const ROMAN_MAP = {
+        'I': 1,
+        'V': 5,
+        'X': 10,
+        'L': 50,
+        'C': 100,
+        'D': 500,
+        'M': 1000
+    };
+    
+    const romanArr = s.split('');
+    const lastVal = ROMAN_MAP[romanArr[romanArr.length - 1]];
+    return romanArr.slice(0, romanArr.length - 1).map((char, idx) => {
+        const [current, next] = [ROMAN_MAP[char], ROMAN_MAP[romanArr[idx + 1]]];
+        return (+(current >= next) * 2 - 1) * current;
+    }).reduce((partialSum, num) => partialSum + num, 0) + lastVal;
+}


### PR DESCRIPTION
This PR aims to make the implementation simpler and more modern.

The performance is about the same -- ~220ms for the older implementation and ~240ms for the suggested change. Likely the slowdown is from the lambda stack overhead. The slowdown is not too bad since I've managed to eliminate the redundant if-else.

I suspect for practical complexity to be a bit worse than the previous implementation.

The tradeoff is that the code is safer and way more readable.